### PR TITLE
Remove dangerous and deprecated APIs

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -62,12 +62,9 @@ urlpatterns = [
     path('api/users/<pk>', UserProfileViewSet.as_view(
         {'get':'retrieve'}
     )),
-    path('api/users', UserProfileViewSet.as_view(
-        {'get':'list'}
-    )),
 
     path('api/upload', UploadViewSet.as_view(
-        {'get':'list', 'post':'create'}
+        {'post':'create'}
     )),
     path('api/upload/<pk>', UploadViewSet.as_view(
         {'get':'retrieve', 'delete':'destroy'}
@@ -86,7 +83,7 @@ urlpatterns = [
     path('api/user-me/roles', BodyRoleViewSet.as_view({'get':'get_my_roles'})),
 
     path('api/roles', BodyRoleViewSet.as_view(
-        {'get':'list', 'post':'create'}
+        {'post':'create'}
     )),
     path('api/roles/<pk>', BodyRoleViewSet.as_view(
         {'get':'retrieve', 'put':'update', 'delete':'destroy'}
@@ -113,9 +110,4 @@ urlpatterns = [
 
     # -------------- DOCS -------------------- #
     path('docs/', get_swagger_view(title='InstiApp API')),
-
-    # -------------- DEPRECATED -------------- #
-    path('user-details/<pk>', pr.user_details),
-    path('event-details/<pk>', pr.event_details),
-    path('body-details/<pk>', pr.body_details),
 ]

--- a/prerender/tests.py
+++ b/prerender/tests.py
@@ -50,9 +50,9 @@ class PrerenderTestCase(APITestCase):
         self.assertContains(response, self.test_body.name)
 
     def test_user_details(self):
-        """Test user-details prerender."""
+        """Test user prerender."""
 
-        url = '/user-details/' + str(self.test_profile.id)
+        url = '/user/' + str(self.test_profile.id)
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
@@ -60,32 +60,32 @@ class PrerenderTestCase(APITestCase):
         self.assertContains(response, self.test_profile.roll_no)
         self.assertNotContains(response, self.test_profile.email)
 
-        url = '/user-details/' + str(self.test_profile.ldap_id)
+        url = '/user/' + str(self.test_profile.ldap_id)
         self.assertEqual(self.client.get(url).content, response.content)
 
     def test_body_details(self):
-        """Test body-details prerender."""
+        """Test body prerender."""
 
-        url = '/body-details/' + str(self.test_body.id)
+        url = '/org/' + str(self.test_body.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.test_body.name)
         self.assertContains(response, self.test_body.events.all()[0].name)
         self.assertContains(response, self.test_body.events.all()[1].name)
 
-        url = '/body-details/' + str(self.test_body.str_id)
+        url = '/org/' + str(self.test_body.str_id)
         self.assertEqual(self.client.get(url).content, response.content)
 
     def test_event_details(self):
-        """Test event-details prerender."""
+        """Test event prerender."""
 
-        url = '/event-details/' + str(self.test_event.id)
+        url = '/event/' + str(self.test_event.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.test_event.name)
         self.assertContains(response, self.test_body.name)
 
-        url = '/event-details/' + str(self.test_event.str_id)
+        url = '/event/' + str(self.test_event.str_id)
         self.assertEqual(self.client.get(url).content, response.content)
 
     def test_tree(self):


### PR DESCRIPTION
Remove these dangerous APIs:
1) `/api/roles [GET]`
2) `/api/upload [GET]`
3) `/api/users [GET]`

Remove these deprecated prerender APIs:
1) `/body-details`
2) `/user-details`
3) `/event-details`