### PR TITLE
Add data field in FCM notification payload

### DIFF
--- a/other/management/commands/push-notify.py
+++ b/other/management/commands/push-notify.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
                             "data": {
                                 "primaryKey": 1
                             }
-                        }
+                        },
                         "data": {
                             "type": notification_type
                             "id": event_id

--- a/other/management/commands/push-notify.py
+++ b/other/management/commands/push-notify.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
                             }
                         },
                         "data": {
-                            "type": notification_type
+                            "type": notification_type,
                             "id": event_id
                         }
                     }

--- a/other/management/commands/push-notify.py
+++ b/other/management/commands/push-notify.py
@@ -10,7 +10,6 @@ from users.models import UserProfile
 from placements.models import BlogEntry
 from events.models import Event
 from news.models import NewsEntry
-from uuid import uuid4
 
 def send_push(subscription, payload):
     """Send a single push notification."""
@@ -58,19 +57,21 @@ class Command(BaseCommand):
 
                 # Get title
                 title = "InstiApp"
-                notification_type = "event"
-                event_id = uuid4()
+                notification_type = None
+                notification_id = None
                 actor = notification.actor
                 if isinstance(actor, Event):
                     title = actor.name
-                    event_type = "event"
-                    event_id = actor.id
+                    notification_type = "event"
+                    notification_id = str(actor.id)
                 if isinstance(actor, BlogEntry):
                     title = actor.title
                     notification_type = "blog-entry"
+                    notification_id = str(actor.id)
                 if isinstance(actor, NewsEntry):
                     title = actor.title
-                    notification_type = "news-entry"     
+                    notification_type = "news-entry"
+                    notification_id = str(actor.id)
 
                 # Send FCM push notification
                 try:
@@ -110,7 +111,7 @@ class Command(BaseCommand):
                         },
                         "data": {
                             "type": notification_type,
-                            "id": event_id
+                            "id": notification_id
                         }
                     }
 

--- a/other/management/commands/push-notify.py
+++ b/other/management/commands/push-notify.py
@@ -10,6 +10,7 @@ from users.models import UserProfile
 from placements.models import BlogEntry
 from events.models import Event
 from news.models import NewsEntry
+from uuid import uuid4
 
 def send_push(subscription, payload):
     """Send a single push notification."""
@@ -57,11 +58,19 @@ class Command(BaseCommand):
 
                 # Get title
                 title = "InstiApp"
+                notification_type = "event"
+                event_id = uuid4()
                 actor = notification.actor
                 if isinstance(actor, Event):
                     title = actor.name
-                if isinstance(actor, BlogEntry) or isinstance(actor, NewsEntry):
+                    event_type = "event"
+                    event_id = actor.id
+                if isinstance(actor, BlogEntry):
                     title = actor.title
+                    notification_type = "blog-entry"
+                if isinstance(actor, NewsEntry):
+                    title = actor.title
+                    notification_type = "news-entry"     
 
                 # Send FCM push notification
                 try:
@@ -98,6 +107,10 @@ class Command(BaseCommand):
                             "data": {
                                 "primaryKey": 1
                             }
+                        }
+                        "data": {
+                            "type": notification_type
+                            "id": event_id
                         }
                     }
 


### PR DESCRIPTION
Add notification-type (event, blog-entry or news-entry) and event-id (if the notification is sent for an event).
#206 
@pulsejet This is not tested as I don't have access to Firebase account!