### PR TITLE
Cast regex match attribute to string explicitly

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -105,5 +105,5 @@ class UserTag(models.Model):
     def match_regex(user, target, regex):
         """Match the user with particular regex."""
         if target and regex and getattr(user, target):
-            return re.match(regex, getattr(user, target))
+            return re.match(regex, str(getattr(user, target)))
         return None


### PR DESCRIPTION
This is necessary since some fields like join_year are stored as numbers