### PR TITLE
Fix event updated notification after event starting

### DIFF
--- a/other/management/commands/notify-event-starting.py
+++ b/other/management/commands/notify-event-starting.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
 
             # Stop the spam!
             event.starting_notified = True
+            event.notify = False
             event.save()
 
             # Event About to Start


### PR DESCRIPTION
Currently, the event is updated when the event is marked to be starting, leading to a second notification that the event was updated.