### PR TITLE
fix(fcm): Add click_action to fcm notification message from data_message

### DIFF
--- a/helpers/fcm.py
+++ b/helpers/fcm.py
@@ -15,7 +15,7 @@ def send_fcm_notification_message(push_service, registration_id, data_message):
     """Send a notification FCM message."""
     push_service.notify_single_device(
         registration_id=registration_id, message_title=data_message['title'],
-        message_body=data_message['verb'], data_message=data_message, sound='default')
+        message_body=data_message['verb'], data_message=data_message, click_action=data_message['click_action'], sound='default')
 
 def send_notification_fcm(push_service, device, data_message):
     """Attempt to send a single FCM notification."""

--- a/helpers/fcm.py
+++ b/helpers/fcm.py
@@ -15,7 +15,8 @@ def send_fcm_notification_message(push_service, registration_id, data_message):
     """Send a notification FCM message."""
     push_service.notify_single_device(
         registration_id=registration_id, message_title=data_message['title'],
-        message_body=data_message['verb'], data_message=data_message, click_action=data_message['click_action'], sound='default')
+        message_body=data_message['verb'], data_message=data_message,
+        click_action=data_message['click_action'], sound='default')
 
 def send_notification_fcm(push_service, device, data_message):
     """Attempt to send a single FCM notification."""

--- a/other/models.py
+++ b/other/models.py
@@ -44,5 +44,7 @@ class Device(models.Model):
         # Add click_action for flutter
         if self.application == 'app.insti.flutter':
             data_message['click_action'] = 'INSTIAPP_NOTIFICATION_CLICK'
+        else:
+            data_message['click_action'] = None
 
         return data_message

--- a/users/tests.py
+++ b/users/tests.py
@@ -128,10 +128,10 @@ class UserTestCase(APITestCase):
         self.assertEqual(dev.supports_rich(), False)
         dev.app_version = '20'
         self.assertEqual(dev.supports_rich(), True)
-        self.assertEqual(len(dev.process_rich(data)), 1)
+        self.assertEqual(dev.process_rich(data)['click_action'], None)
         dev.application = 'app.insti.flutter'
         self.assertEqual(dev.supports_rich(), False)
-        self.assertEqual(len(dev.process_rich(data)), 2)
+        self.assertNotEqual(dev.process_rich(data)['click_action'], None)
         dev.application = 'app.insti.ios'
         self.assertEqual(dev.supports_rich(), True)
 


### PR DESCRIPTION
The argument `click_action` should be provided to `FCMNotification.notify_single_device` not in the `data_message`. 
