### PR TITLE
fix(fcm): Fix click_action to correct string

### DIFF
--- a/other/models.py
+++ b/other/models.py
@@ -43,7 +43,7 @@ class Device(models.Model):
 
         # Add click_action for flutter
         if self.application == 'app.insti.flutter':
-            data_message['click_action'] = 'INSTIAPP_NOTIFICATION_CLICK'
+            data_message['click_action'] = 'FLUTTER_NOTIFICATION_CLICK'
         else:
             data_message['click_action'] = None
 


### PR DESCRIPTION
Actually, the string `click_action` is not configurable, it has to be `FLUTTER_NOTIFICATION_CLICK` otherwise clicking notification wouldn't fire the callback. 