### PR TITLE
Added a new field called 'upvoted' to the serialised complaint response

### DIFF
--- a/venter/tests.py
+++ b/venter/tests.py
@@ -146,12 +146,24 @@ class VenterTestCase(APITestCase):
         # UpVote
         response = self.client.get(url + '1')
         self.assertEqual(response.status_code, 200)
+
+        # Verify the addition of the user to the array for 'users_up_voted'
         self.assertEqual(len(response.data['users_up_voted']), 1)
+
+        # Verify user's upvote status for the complaint
+        response = self.client.get(complaint_url)
+        self.assertEqual(response.data['upvoted'], True)
 
         # UnUpVote
         response = self.client.get(url + '0')
         self.assertEqual(response.status_code, 200)
+
+        # Verify the removal of the user from the 'users_up_voted' array
         self.assertEqual(len(response.data['users_up_voted']), 0)
+
+        # Verify user's upvote status for the complaint
+        response = self.client.get(complaint_url)
+        self.assertEqual(response.data['upvoted'], False)
 
         # Test for Complaint Subscription
         url = '/api/venter/complaints/' + cid + '/subscribe'

--- a/venter/views.py
+++ b/venter/views.py
@@ -48,9 +48,11 @@ class ComplaintViewSet(viewsets.ModelViewSet):
         serialized = ComplaintSerializer(
             complaint, context={'request': request}).data
 
-        serialized['is_subscribed'] = False
-        if request.user.profile in complaint.subscriptions.all():
-            serialized['is_subscribed'] = True
+        is_sub = request.user.is_authenticated and request.user.profile in complaint.subscriptions.all()
+        serialized['is_subscribed'] = is_sub
+
+        upvoted = request.user.is_authenticated and request.user.profile in complaint.users_up_voted.all()
+        serialized['upvoted'] = upvoted
 
         return Response(serialized)
 
@@ -85,6 +87,9 @@ class ComplaintViewSet(viewsets.ModelViewSet):
         for complaint_object, serialized_object in zip(complaint, serialized):
             is_sub = request.user.is_authenticated and request.user.profile in complaint_object.subscriptions.all()
             serialized_object['is_subscribed'] = is_sub
+
+            upvoted = request.user.is_authenticated and request.user.profile in complaint_object.users_up_voted.all()
+            serialized_object['upvoted'] = upvoted
 
         return Response(serialized)
 


### PR DESCRIPTION
Fixed up the code for complaint retrieval by applying the user.is_authenticated check to it.

Added a new field 'upvoted' to the complaint response in order to indicate whether a given user has upvoted the complaint in question.

This is needed since currently in Angular, the upvotes are being set manually each time the page is loaded by comparing the user's id to each upvoted user in each complaint in the list. This is computationally expensive. This is also being called every time a person upvotes a complaint in the home page. In order to reduce this overhead, I'm adding a Boolean field called 'upvoted' to the complaint response for a list as well as the individual complaints.