### PR TITLE
Added complaint pagination and its associated tests to venter module

### DIFF
--- a/venter/tests.py
+++ b/venter/tests.py
@@ -30,11 +30,18 @@ class VenterTestCase(APITestCase):
         def create_complaint(user, **kwargs):
             Complaints.objects.create(created_by=user, **kwargs)
 
+        # Creating 4 dummy complaints, one of which has a "DELETED" status
         create_complaint(self.user.profile)
+        create_complaint(get_new_user().profile)
         create_complaint(get_new_user().profile)
         create_complaint(self.user.profile, status=STATUS_DELETED)
 
         url = '/api/venter/complaints'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 3)
+
+        url = '/api/venter/complaints?from=0&num=2'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)

--- a/venter/views.py
+++ b/venter/views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from rest_framework.generics import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.response import Response
+from helpers.misc import query_from_num
 from roles.helpers import login_required_ajax
 
 from venter.models import Complaints
@@ -80,6 +81,9 @@ class ComplaintViewSet(viewsets.ModelViewSet):
             clauses = (Q(tags__tag_uri__icontains=p) for p in val)
             query = reduce(operator.or_, clauses)
             complaints = complaints.filter(query)
+
+        # Paginate the complaint page using the helper function
+        complaints = query_from_num(request, 10, complaints)
 
         # Serialize and return
         serialized = ComplaintSerializer(


### PR DESCRIPTION
Issue #349 should be resolved via this PR.

**A small note about the functionality to prevent any confusion:**
The helper function 'query_from_num' is performing a slicing operation on the complaint list queryset. Thus, I have to perform filtering and searching operations on the list before I get to pagination. This behavior is enforced by django itself, since it forbids filtering operations being performed on sliced querysets. Thus, you'll find that pagination is the final operation being performed on the queryset before it is serialised. The code snippet is given below.

    def list(self, request):
        """Get a list of non-deleted complaints.
        To filter by current user, add a query parameter {?filter}"""

        # Get the list of complaints excluding objects marked deleted
        complaints = self.queryset.prefetch_related(
            'subscriptions', 'users_up_voted').exclude(status='Deleted')

        # Check if the user specific filter is present
        if 'filter' in request.GET and request.user.is_authenticated:
            complaints = complaints.filter(created_by=request.user.profile)

        # Filter for a particular word search
        if 'search' in request.GET:
            val = request.query_params.get('search')
            complaints = complaints.filter(description__icontains=val)

        # For multiple tags and single tags
        if 'tags' in request.GET:
            val = request.query_params.getlist('tags')
            clauses = (Q(tags__tag_uri__icontains=p) for p in val)
            query = reduce(operator.or_, clauses)
            complaints = complaints.filter(query)

        # Paginate the complaint page using the helper function
        complaints = query_from_num(request, 10, complaints)

        # Serialize and return
        serialized = ComplaintSerializer(
            complaints, context={'request': request}, many=True).data