### PR TITLE
fix(fcm): Change to non-rich notifs for iOS

### DIFF
--- a/other/models.py
+++ b/other/models.py
@@ -33,7 +33,7 @@ class Device(models.Model):
         if self.application == 'app.insti.flutter':
             return False
         if self.application == 'app.insti.ios':
-            return True
+            return False
 
         # Try parsing the app version
         try:

--- a/users/tests.py
+++ b/users/tests.py
@@ -149,7 +149,7 @@ class UserTestCase(APITestCase):
         self.assertEqual(dev.supports_rich(), False)
         self.assertNotEqual(dev.process_rich(data)['click_action'], None)
         dev.application = 'app.insti.ios'
-        self.assertEqual(dev.supports_rich(), True)
+        self.assertEqual(dev.supports_rich(), False)
 
     def test_get_noauth(self):
         """Test privacy with no auth."""


### PR DESCRIPTION
Since iOS flutter also doesn't support FCM data message in the background for now, we need to send notification message instead for instant notifications.